### PR TITLE
feat: http2 support

### DIFF
--- a/lib/formatEntry.js
+++ b/lib/formatEntry.js
@@ -11,7 +11,7 @@ warning.create(WARNING_NAME, 'FSTEH002', 'cors attribute invalid.')
 warning.create(WARNING_NAME, 'FSTEH003', 'rel attribute invalid.')
 
 module.exports = function formatEntry (earlyHint, opts) {
-  if (typeof earlyHint === 'string') return earlyHint
+  if (typeof earlyHint === 'string') return earlyHint.toLocaleLowerCase().startsWith('link: ') ? earlyHint.slice(6) : earlyHint
   const {
     href,
     rel,
@@ -55,5 +55,6 @@ module.exports = function formatEntry (earlyHint, opts) {
       warn && warning.emit('FSTEH002')
       break
   }
-  return `Link: <${href}>; rel=${rel}${as.length !== 0 ? '; as=' : ''}${as}${_cors.length !== 0 ? '; ' : ''}${_cors}`
+
+  return `<${href}>; rel=${rel}${as.length !== 0 ? '; as=' : ''}${as}${_cors.length !== 0 ? '; ' : ''}${_cors}`
 }

--- a/lib/protocol/http.js
+++ b/lib/protocol/http.js
@@ -1,0 +1,30 @@
+// TODO: remove after node@18 End-of-Life
+'use strict'
+
+const CRLF = '\r\n'
+const EarlyHints = `HTTP/1.1 103 Early Hint${CRLF}`
+
+function write (reply, headers) {
+  let message = ''
+  for (const key of Object.keys(headers)) {
+    let value = ''
+    if (Array.isArray(headers[key])) {
+      value = headers[key].join(', ')
+    } else {
+      value = headers[key]
+    }
+    message += `${key}: ${value}${CRLF}`
+  }
+
+  return new Promise(function (resolve) {
+    if (reply.raw.socket === null) {
+      resolve()
+      return
+    }
+    reply.raw.socket.write(`${EarlyHints}${message}${CRLF}`, 'ascii', () => {
+      resolve()
+    })
+  })
+}
+
+module.exports = write

--- a/lib/protocol/http2.js
+++ b/lib/protocol/http2.js
@@ -1,0 +1,18 @@
+// TODO: remove after node@18 End-of-Life
+'use strict'
+
+function writeEarlyHints (reply, headers) {
+  return new Promise(function (resolve) {
+    if (reply.raw.socket === null) {
+      resolve()
+      return
+    }
+    reply.raw.stream.additionalHeaders({
+      ':status': '103',
+      ...headers
+    })
+    resolve()
+  })
+}
+
+module.exports = writeEarlyHints

--- a/lib/protocol/native.js
+++ b/lib/protocol/native.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function write (reply, headers) {
+  return new Promise(function (resolve) {
+    reply.raw.writeEarlyHints(headers, () => {
+      resolve()
+    })
+  })
+}
+
+module.exports = write

--- a/lib/support.js
+++ b/lib/support.js
@@ -1,0 +1,10 @@
+const { version } = require('process')
+
+const [major, minor, patch] = version.slice(1).split('.').map(Number)
+
+// Added in v18.11.0
+// Refs: https://nodejs.org/dist/latest-v18.x/docs/api/http.html#responsewriteearlyhintshints-callback
+// TODO: remove after node@18 End-of-Life
+const nativeSupport = (major === 18 && minor >= 11 && patch >= 0) || major > 18
+
+module.exports = nativeSupport

--- a/test/formatEntry.test.js
+++ b/test/formatEntry.test.js
@@ -3,9 +3,9 @@
 const { test } = require('tap')
 const formatEntry = require('../lib/formatEntry')
 
-test('formatEntry: value string gets returned unmodified', t => {
+test('formatEntry: remove Link: prefix', t => {
   t.plan(1)
-  t.equal(formatEntry('Link: </style.css>; rel=preload; as=style'), 'Link: </style.css>; rel=preload; as=style')
+  t.equal(formatEntry('Link: </style.css>; rel=preload; as=style'), '</style.css>; rel=preload; as=style')
 })
 
 test('formatEntry: entryHint without href attribute should throw an error', t => {
@@ -20,14 +20,14 @@ test('formatEntry: entryHint without rel attribute should throw an error', t => 
 
 test('formatEntry: entryHint should create valid values', t => {
   t.plan(8)
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'anonymous', as: 'script' }), 'Link: </>; rel=preconnect; as=script; crossorigin=anonymous')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'use-credentials', as: 'script' }), 'Link: </>; rel=preconnect; as=script; crossorigin=use-credentials')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: true, as: 'script' }), 'Link: </>; rel=preconnect; as=script; crossorigin')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'crossorigin', as: 'script' }), 'Link: </>; rel=preconnect; as=script; crossorigin')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: false, as: 'script' }), 'Link: </>; rel=preconnect; as=script')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: false }), 'Link: </>; rel=preconnect')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect' }), 'Link: </>; rel=preconnect')
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'anonymous' }), 'Link: </>; rel=preconnect; crossorigin=anonymous')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'anonymous', as: 'script' }), '</>; rel=preconnect; as=script; crossorigin=anonymous')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'use-credentials', as: 'script' }), '</>; rel=preconnect; as=script; crossorigin=use-credentials')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: true, as: 'script' }), '</>; rel=preconnect; as=script; crossorigin')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'crossorigin', as: 'script' }), '</>; rel=preconnect; as=script; crossorigin')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: false, as: 'script' }), '</>; rel=preconnect; as=script')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: false }), '</>; rel=preconnect')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect' }), '</>; rel=preconnect')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'anonymous' }), '</>; rel=preconnect; crossorigin=anonymous')
 })
 
 test('formatEntry: check for warning FSTEH001', t => {
@@ -39,7 +39,7 @@ test('formatEntry: check for warning FSTEH001', t => {
     t.equal(warning.code, 'FSTEH001')
     t.equal(warning.message, 'as attribute invalid.')
   }
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: false, as: 'invalid' }, { warn: true }), 'Link: </>; rel=preconnect; as=invalid')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: false, as: 'invalid' }, { warn: true }), '</>; rel=preconnect; as=invalid')
   t.teardown(() => {
     process.removeAllListeners('warning')
   })
@@ -54,7 +54,7 @@ test('formatEntry: check for warning FSTEH002', t => {
     t.equal(warning.code, 'FSTEH002')
     t.equal(warning.message, 'cors attribute invalid.')
   }
-  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'invalid', as: 'script' }, { warn: true }), 'Link: </>; rel=preconnect; as=script')
+  t.equal(formatEntry({ href: '/', rel: 'preconnect', cors: 'invalid', as: 'script' }, { warn: true }), '</>; rel=preconnect; as=script')
   t.teardown(() => {
     process.removeAllListeners('warning')
   })
@@ -69,7 +69,7 @@ test('formatEntry: check for warning FSTEH003', t => {
     t.equal(warning.code, 'FSTEH003')
     t.equal(warning.message, 'rel attribute invalid.')
   }
-  t.equal(formatEntry({ href: '/', rel: 'invalid', cors: false, as: 'script' }, { warn: true }), 'Link: </>; rel=invalid; as=script')
+  t.equal(formatEntry({ href: '/', rel: 'invalid', cors: false, as: 'script' }, { warn: true }), '</>; rel=invalid; as=script')
   t.teardown(() => {
     process.removeAllListeners('warning')
   })

--- a/test/warn.test.js
+++ b/test/warn.test.js
@@ -6,7 +6,7 @@ const eh = require('../index')
 const { Client } = require('undici')
 
 test('Should not warn on valid entries', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const infos = []
 
   const fastify = Fastify()
@@ -42,13 +42,12 @@ test('Should not warn on valid entries', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script')
 })
 
 test('Should warn on invalid as (FSTEH001)', async (t) => {
-  t.plan(9)
+  t.plan(8)
   const infos = []
 
   const fastify = Fastify()
@@ -86,13 +85,12 @@ test('Should warn on invalid as (FSTEH001)', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=invalid')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=invalid, </script.js>; rel=preload; as=script')
 })
 
 test('Should warn on invalid cors (FSTEH002)', async (t) => {
-  t.plan(9)
+  t.plan(8)
   const infos = []
 
   const fastify = Fastify()
@@ -130,13 +128,12 @@ test('Should warn on invalid cors (FSTEH002)', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script')
 })
 
 test('Should warn on invalid rel (FSTEH003)', async (t) => {
-  t.plan(9)
+  t.plan(8)
   const infos = []
 
   const fastify = Fastify()
@@ -174,13 +171,12 @@ test('Should warn on invalid rel (FSTEH003)', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=invalid; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=invalid; as=style, </script.js>; rel=preload; as=script')
 })
 
 test('Should not warn on invalid as (FSTEH001) if warn is false', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const infos = []
 
   const fastify = Fastify()
@@ -216,13 +212,12 @@ test('Should not warn on invalid as (FSTEH001) if warn is false', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=invalid')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=invalid, </script.js>; rel=preload; as=script')
 })
 
 test('Should not warn on invalid cors (FSTEH002) if warn is false', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const infos = []
 
   const fastify = Fastify()
@@ -258,13 +253,12 @@ test('Should not warn on invalid cors (FSTEH002) if warn is false', async (t) =>
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script')
 })
 
 test('Should not warn on invalid rel (FSTEH003) if warn is false', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const infos = []
 
   const fastify = Fastify()
@@ -300,7 +294,6 @@ test('Should not warn on invalid rel (FSTEH003) if warn is false', async (t) => 
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=invalid; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=invalid; as=style, </script.js>; rel=preload; as=script')
 })

--- a/test/writeEarlyHints.test.js
+++ b/test/writeEarlyHints.test.js
@@ -72,7 +72,7 @@ test('Should add Early Hints headers - object', async (t) => {
 })
 
 test('Should add Early Hints headers - object with array property', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const payload = { hello: 'world' }
   const infos = []
 
@@ -103,9 +103,8 @@ test('Should add Early Hints headers - object with array property', async (t) =>
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script')
 })
 
 test('Should add Early Hints headers - array', async (t) => {
@@ -144,7 +143,7 @@ test('Should add Early Hints headers - array', async (t) => {
 })
 
 test('Should add Early Hints headers - array with same header', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const payload = { hello: 'world' }
   const infos = []
 
@@ -176,9 +175,8 @@ test('Should add Early Hints headers - array with same header', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script')
 })
 
 test('Should add multiple Early Hints headers', async (t) => {

--- a/test/writeEarlyHintsLinks.test.js
+++ b/test/writeEarlyHintsLinks.test.js
@@ -35,7 +35,7 @@ test('Should not add Early Hints', async (t) => {
 })
 
 test('Should add Early Hints headers', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const infos = []
 
   const fastify = Fastify()
@@ -66,7 +66,6 @@ test('Should add Early Hints headers', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.equal(typeof infos[0].headers === 'object', true)
-  t.equal(Array.isArray(infos[0].headers.link), true)
-  t.equal(infos[0].headers.link[0], '</style.css>; rel=preload; as=style')
-  t.equal(infos[0].headers.link[1], '</script.js>; rel=preload; as=script')
+  t.equal(typeof infos[0].headers.link === 'string', true)
+  t.equal(infos[0].headers.link, '</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script')
 })


### PR DESCRIPTION
@Uzlopak Sorry for duplication, but it should be how I would like to implement the `http2` with `native solution`.

It still missing `test` for `http2`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
